### PR TITLE
GARD_detect HPC issues, closes #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ __Important:__ PoSeiDon needs nucleotide sequences with a correct open reading f
 
 ### Profiles
 
-Nextflow can be easily executed on different environments like your local machine, a high-performance cluster or the cloud. Different `-profile` are used to tell Nextflow which system should be used. For local execution `-profile local,docker` should be used (and is also the default). You can also run PoSeiDon on a HPC using Singularity via `-profile lsf,singularity` or `-profile slurm,singularity`. In such cases, please also consider to adjust `--cachedir` to point where to store Singularity images on your cluster. The parameter `--workdir` might be also helpful to adjust where to store temporary working directories (e.g. use `/scratch` instead of `/tmp` depending on your HPC configuration.) 
+Nextflow can be easily executed on different environments like your local machine, a high-performance cluster or the cloud. Different `-profile` are used to tell Nextflow which system should be used. For local execution `-profile local,docker` should be used (and is also the default). You can also run PoSeiDon on a HPC using Singularity via `-profile lsf,singularity`, `-profile slurm,singularity` or `-profile sge,singularity`. In such cases, please also consider to adjust `--cachedir` to point where to store Singularity images on your cluster. The parameter `--workdir` might be also helpful to adjust where to store temporary working directories (e.g. use `/scratch` instead of `/tmp` depending on your HPC configuration.) 
 
 ### Examples 
 

--- a/modules/gard.nf
+++ b/modules/gard.nf
@@ -15,15 +15,17 @@ process gard_detect {
     OPENMPI_RUN='--allow-run-as-root'
     HYPHYMPI='hyphympi'
 
-    TMPDIR=\${PWD}
-
+    TMPDIR=/tmp
+    mv \$(readlink -f ${aln}) \$TMPDIR/${aln}
+    
     OUTPUT=\${TMPDIR}/gard
     ALN=\${TMPDIR}/${aln}
     MODEL=${model}
 
     (echo "\${ALN}"; echo "\${ALN}"; echo "\${MODEL}"; echo "${params.gard_rate_variation}"; echo "${params.gard_rate_classes}"; echo "\${OUTPUT}") | \${OPENMPI} \${OPENMPI_RUN} -np ${task.cpus} \${HYPHYMPI} \${GARD_TEMPLATE_BATCH} &> \${TMPDIR}/gard.log
 
-    mv gard gard.html
+    mv \${TMPDIR}/gard.log gard.log
+    mv \${TMPDIR}/gard gard.html
 
     # check if GARD was able to detect breakpoints
     if grep -q "ERROR: Too few sites for c-AIC inference." gard.log; then 
@@ -40,9 +42,11 @@ process gard_detect {
             gard_splits_file=\${TMPDIR}/gard_splits
             gard_processor_log=\${TMPDIR}/gard_processor.log
             (echo "\${gard_result_file}"; echo "\${gard_splits_file}") | \${OPENMPI} \${OPENMPI_RUN} -np ${task.cpus} \${HYPHYMPI} \${GARD_PROCESSOR_TEMPLATE_BATCH} &> \$gard_processor_log
+            mv \$gard_processor_log gard_processor.log
         fi
     fi
 
+    mv \$TMPDIR/${aln} ${aln}
     """
 }
 

--- a/modules/gard.nf
+++ b/modules/gard.nf
@@ -16,7 +16,7 @@ process gard_detect {
     HYPHYMPI='hyphympi'
 
     TMPDIR=/tmp
-    mv \$(readlink -f ${aln}) \$TMPDIR/${aln}
+    cp \$(readlink -f ${aln}) \$TMPDIR/${aln}
     
     OUTPUT=\${TMPDIR}/gard
     ALN=\${TMPDIR}/${aln}

--- a/nextflow.config
+++ b/nextflow.config
@@ -84,6 +84,19 @@ profiles {
         includeConfig 'configs/node.config'
     }
 
+    sge {
+        workDir = params.workdir
+        executor {
+            name = "sge"
+            queueSize = 200
+        }        
+        params.cloudProcess = true
+        process.cache = "lenient"
+        process.clusterOptions = '-S /bin/bash' 
+        process.penv = 'smp'
+        includeConfig 'configs/node.config'
+    }    
+
     
     //engines
     docker { 

--- a/poseidon.nf
+++ b/poseidon.nf
@@ -541,6 +541,7 @@ def helpMSG() {
                              local,conda
                              lsf,docker,singularity (adjust workdir and cachedir according to your HPC config)
                              slurm,conda (adjust workdir and cachedir according to your HPC config)
+                             sge,conda (adjust workdir and cachedir according to your HPC config)
                              gcloud,docker (GCP google-lifescience with docker)
                              ${c_reset}
     """.stripIndent()


### PR DESCRIPTION
- changed /TEMPDIR from $(PWD) to `/tmp` because path was too long for MPI
- copy `${aln}` to /TEMPDIR since `GARD` wasn't able to follow the symlink on the cluster apparently
- adjust paths to new /TEMPDIR
